### PR TITLE
Offline improvements

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -333,6 +333,8 @@ PODS:
     - React-Core
   - react-native-music-control (1.4.1):
     - React-Core
+  - react-native-netinfo (9.3.0):
+    - React-Core
   - react-native-pdf (6.5.0):
     - React-Core
   - react-native-progress-bar-android (1.0.4):
@@ -555,6 +557,7 @@ DEPENDENCIES:
   - react-native-camera (from `../node_modules/react-native-camera`)
   - react-native-maps (from `../node_modules/react-native-maps`)
   - react-native-music-control (from `../node_modules/react-native-music-control`)
+  - "react-native-netinfo (from `../node_modules/@react-native-community/netinfo`)"
   - react-native-pdf (from `../node_modules/react-native-pdf`)
   - "react-native-progress-bar-android (from `../node_modules/@react-native-community/progress-bar-android`)"
   - react-native-safe-area-context (from `../node_modules/react-native-safe-area-context`)
@@ -681,6 +684,8 @@ EXTERNAL SOURCES:
     :path: "../node_modules/react-native-maps"
   react-native-music-control:
     :path: "../node_modules/react-native-music-control"
+  react-native-netinfo:
+    :path: "../node_modules/@react-native-community/netinfo"
   react-native-pdf:
     :path: "../node_modules/react-native-pdf"
   react-native-progress-bar-android:
@@ -800,6 +805,7 @@ SPEC CHECKSUMS:
   react-native-camera: 3eae183c1d111103963f3dd913b65d01aef8110f
   react-native-maps: 8b8bfada2c86205a7f5a07dd1f92f29b33ea83aa
   react-native-music-control: 3fc719c179a6562e18af1ac6e30ba9e33b397a31
+  react-native-netinfo: 129bd99f607a2dc5bb096168f3e5c150fd1f1c95
   react-native-pdf: de35db0d8f1e5d37e65e887554f7d4bd062af56b
   react-native-progress-bar-android: be43138ab7da30d51fc038bafa98e9ed594d0c40
   react-native-safe-area-context: ebf8c413eb8b5f7c392a036a315eb7b46b96845f

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@dudigital/react-native-zoomable-view": "^1.1.3",
     "@react-native-community/async-storage": "^1.12.1",
     "@react-native-community/masked-view": "^0.1.11",
+    "@react-native-community/netinfo": "^9.3.0",
     "@react-native-community/progress-bar-android": "^1.0.4",
     "@react-native-community/push-notification-ios": "^1.10.1",
     "@react-native-firebase/app": "^14.9.1",

--- a/src/features/experience/screens/ExperienceDetailsScreen.tsx
+++ b/src/features/experience/screens/ExperienceDetailsScreen.tsx
@@ -29,7 +29,6 @@ const ExperienceDetailsScreen: React.FC = () => {
   const route = useRoute<Route>();
   const { experience, experienceId } = route.params;
   const id = experience?._id || experienceId || "";
-  console.log("id", experienceId);
   const dispatch = useDispatch();
   const [isAuthorModalVisible, setAuthorModalVisible] = useState(false);
 
@@ -99,7 +98,6 @@ const ExperienceDetailsScreen: React.FC = () => {
       ]
     );
   };
-  console.log("display", displayExperience);
   const sizeInMb = (displayExperience.metaData.size / 1000000).toFixed(2);
 
   const padding = 10;

--- a/src/features/experience/screens/ExperienceDetailsScreen.tsx
+++ b/src/features/experience/screens/ExperienceDetailsScreen.tsx
@@ -1,5 +1,5 @@
 import { RouteProp, useNavigation, useRoute } from "@react-navigation/native";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { Alert, StyleSheet, View } from "react-native";
 import FastImage from "react-native-fast-image";
 import { ScrollView } from "react-native-gesture-handler";
@@ -15,7 +15,10 @@ import {
 } from "../../../store/experience/experienceReducer";
 import { selectExperience } from "../../../store/experience/experienceSelectors";
 import { RootState } from "../../../store/rootReducer";
-import { ExperienceSnapshotData } from "../../../types/common/experience";
+import {
+  ExperienceRefData,
+  ExperienceSnapshotData,
+} from "../../../types/common/experience";
 import { ExperienceManagementProp } from "../../../types/nav/experienceManagement";
 import AuthorDetails from "../../experiences/components/AuthorDetails";
 
@@ -26,8 +29,10 @@ const ExperienceDetailsScreen: React.FC = () => {
   const route = useRoute<Route>();
   const { experience, experienceId } = route.params;
   const id = experience?._id || experienceId || "";
+  console.log("id", experienceId);
   const dispatch = useDispatch();
   const [isAuthorModalVisible, setAuthorModalVisible] = useState(false);
+
   const experienceSnapshot = useSelector<
     RootState,
     ExperienceSnapshotData | undefined
@@ -35,9 +40,6 @@ const ExperienceDetailsScreen: React.FC = () => {
   useEffect(() => {
     dispatch(loadExperience({ id }));
   }, [dispatch, id]);
-  const onPressAuthor = (open: boolean) => () => {
-    setAuthorModalVisible(open);
-  };
   const ref = useRef<MapView>(null);
 
   useEffect(() => {
@@ -54,14 +56,32 @@ const ExperienceDetailsScreen: React.FC = () => {
     }
   }, [experienceSnapshot, nav]);
   const [t] = useTranslation(["manage", "glossary"]);
-  if (!experienceSnapshot) {
+
+  // This is so we can display some data from the ref, even if we don't have a complete snapshot yet
+  const displayExperience: ExperienceRefData | undefined = useMemo(() => {
+    if (experience) return experience;
+    if (experienceSnapshot)
+      return {
+        _id: experienceSnapshot.data._id,
+        snapshotId: experienceSnapshot._id,
+        name: experienceSnapshot.data.name,
+        description: experienceSnapshot.data.description,
+        metaData: experienceSnapshot.metaData,
+      };
+    return undefined;
+  }, [experienceSnapshot, experience]);
+
+  if (!displayExperience) {
     return <ProgressBar />;
   }
-  const sizeInMb = (experienceSnapshot.metaData.size / 1000000).toFixed(2);
+
+  const onPressAuthor = (open: boolean) => () => {
+    setAuthorModalVisible(open);
+  };
   const onPressPlay = () => {
     dispatch(setSelectedExperience({ id: experienceSnapshot?.data._id }));
     nav.goBack();
-    nav.navigate("MapScreen");
+    nav.navigate("MapScreen", {});
   };
   const onPressDownload = () => {
     Alert.alert(
@@ -79,6 +99,9 @@ const ExperienceDetailsScreen: React.FC = () => {
       ]
     );
   };
+  console.log("display", displayExperience);
+  const sizeInMb = (displayExperience.metaData.size / 1000000).toFixed(2);
+
   const padding = 10;
   return (
     <View style={styles.container}>
@@ -109,19 +132,19 @@ const ExperienceDetailsScreen: React.FC = () => {
       </MapView>
       <ScrollView contentContainerStyle={styles.scrollView}>
         <View>
-          {experienceSnapshot.data.description ? (
+          {displayExperience.description ? (
             <Paragraph style={styles.description}>
-              {experienceSnapshot.data.description}
+              {displayExperience.description}
             </Paragraph>
           ) : null}
           <View style={styles.author}>
             <Chip
               onPress={onPressAuthor(true)}
               avatar={
-                experienceSnapshot.metaData.ownerPublicProfile.photoURL ? (
+                displayExperience.metaData.ownerPublicProfile.photoURL ? (
                   <FastImage
                     source={{
-                      uri: experienceSnapshot.metaData.ownerPublicProfile
+                      uri: displayExperience.metaData.ownerPublicProfile
                         .photoURL,
                     }}
                   />
@@ -130,7 +153,7 @@ const ExperienceDetailsScreen: React.FC = () => {
                 )
               }
             >
-              {experienceSnapshot.metaData.ownerPublicProfile.displayName}
+              {displayExperience.metaData.ownerPublicProfile.displayName}
             </Chip>
           </View>
           <Button
@@ -142,11 +165,11 @@ const ExperienceDetailsScreen: React.FC = () => {
             {t("manage:playExperience")}
           </Button>
           <Button
-            disabled={experienceSnapshot.downloaded}
+            disabled={experienceSnapshot?.downloaded}
             onPress={onPressDownload}
             mode="text"
           >
-            {experienceSnapshot.downloaded
+            {experienceSnapshot?.downloaded
               ? t("manage:downloaded")
               : t("manage:downloadSizeInMb", { sizeInMb })}
           </Button>
@@ -155,7 +178,7 @@ const ExperienceDetailsScreen: React.FC = () => {
       <AuthorDetails
         onHide={onPressAuthor(false)}
         isVisible={isAuthorModalVisible}
-        author={experienceSnapshot.metaData.ownerPublicProfile}
+        author={displayExperience.metaData.ownerPublicProfile}
       />
     </View>
   );

--- a/src/features/experience/screens/MapScreen.tsx
+++ b/src/features/experience/screens/MapScreen.tsx
@@ -1,9 +1,11 @@
 import React, { useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
 import { StyleSheet, View } from "react-native";
 import MapView, { Region } from "react-native-maps";
 import { useSelector } from "react-redux";
 import { selectCurrentExperience } from "../../../store/experience/experienceSelectors";
 import { selectIsOnboardingComplete } from "../../../store/onboarding/onboardingSelectors";
+import OfflineBanner from "../../../ui/OfflineBanner";
 import ActionMenu from "../components/ActionMenu";
 import ExperienceMapView from "../components/ExperienceMapView";
 import KeyModal from "../components/KeyModal";
@@ -70,6 +72,8 @@ const MapScreen: React.FC = () => {
     }
   };
 
+  const [t] = useTranslation("manage");
+
   return (
     <View style={styles.map}>
       <MapView
@@ -84,6 +88,9 @@ const MapScreen: React.FC = () => {
       >
         <ExperienceMapView centreMap={centreMap} />
       </MapView>
+      {!experience?.downloaded && (
+        <OfflineBanner title={t("youAreOfflineAndNotDownloaded")} />
+      )}
       <ActionMenu
         onPressCentre={centreMap}
         isRegionVisible={isRegionVisible}

--- a/src/features/experiences/components/AuthorDetails.tsx
+++ b/src/features/experiences/components/AuthorDetails.tsx
@@ -4,7 +4,6 @@ import { StyleSheet, View } from "react-native";
 import Modal from "react-native-modal";
 import { Avatar, Colors, Paragraph, Title } from "react-native-paper";
 import Animated from "react-native-reanimated";
-import MaterialCommunityIcon from "react-native-vector-icons/MaterialCommunityIcons";
 import { PublicProfile } from "../../../types/common/experience";
 
 type Props = {
@@ -32,7 +31,7 @@ const AuthorDetails: React.FC<Props> = ({ author, isVisible, onHide }) => {
           {author.photoURL ? (
             <Avatar.Image size={48} source={{ uri: author.photoURL }} />
           ) : (
-            <MaterialCommunityIcon size={48} name="account-circle" />
+            <Avatar.Text size={48} label={author.displayName} />
           )}
           <Title style={styles.title}>{author.displayName}</Title>
         </View>

--- a/src/features/experiences/components/AuthorDetails.tsx
+++ b/src/features/experiences/components/AuthorDetails.tsx
@@ -12,6 +12,8 @@ type Props = {
   onHide: () => void;
 };
 
+const AVATAR_SIZE = 48;
+
 const AuthorDetails: React.FC<Props> = ({ author, isVisible, onHide }) => {
   const { colors } = useTheme();
   return (
@@ -29,9 +31,12 @@ const AuthorDetails: React.FC<Props> = ({ author, isVisible, onHide }) => {
       >
         <View style={styles.titleContainer}>
           {author.photoURL ? (
-            <Avatar.Image size={48} source={{ uri: author.photoURL }} />
+            <Avatar.Image
+              size={AVATAR_SIZE}
+              source={{ uri: author.photoURL }}
+            />
           ) : (
-            <Avatar.Text size={48} label={author.displayName} />
+            <Avatar.Text size={AVATAR_SIZE} label={author.displayName} />
           )}
           <Title style={styles.title}>{author.displayName}</Title>
         </View>

--- a/src/features/experiences/components/ExperienceItem.tsx
+++ b/src/features/experiences/components/ExperienceItem.tsx
@@ -24,7 +24,7 @@ const ExperienceItem: React.FC<Props> = ({ experience }) => {
   const dispatch = useDispatch();
   const onPress = () => {
     nav.navigate("ExperienceDetailsScreen", {
-      experience: experience.data,
+      experienceId: experience.data._id,
     });
   };
   const onPressPlay = () => {

--- a/src/hooks/useIsOnline.ts
+++ b/src/hooks/useIsOnline.ts
@@ -1,0 +1,8 @@
+import { useNetInfo } from "@react-native-community/netinfo";
+
+const useIsOnline = () => {
+  const info = useNetInfo();
+  return info.isInternetReachable;
+};
+
+export default useIsOnline;

--- a/src/i18n/en/index.json
+++ b/src/i18n/en/index.json
@@ -20,7 +20,9 @@
     "downloadExplanation": "This will allow you to view this experience's media while offline.\n\nIt cannot guarantee that the map layer will be visible while offline.",
     "removeExperience": "Remove experience?",
     "removeExplanation": "Are you sure you want to remove this experience?",
-    "experienceRemoved": "Experience removed"
+    "experienceRemoved": "Experience removed",
+    "youAreOffline": "You appear to be offline",
+    "youAreOfflineAndNotDownloaded": "You appear to be offline. This experience has not been downloaded, so some media may be unavailable."
   },
   "route": {
     "route": "Route",

--- a/src/media/ImageScreen.tsx
+++ b/src/media/ImageScreen.tsx
@@ -4,6 +4,7 @@ import React from "react";
 import { StyleSheet, View } from "react-native";
 import FastImage from "react-native-fast-image";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { getPath } from "../store/mediaService";
 import { MapNaviationProp } from "../types/nav/map";
 import AcknowledgementsOverlay from "./AcknowledgementsOverlay";
 
@@ -28,7 +29,7 @@ const ImageScreen: React.FC = () => {
           <FastImage
             style={styles.image}
             resizeMode="contain"
-            source={{ uri: media.path }}
+            source={{ uri: getPath(media) }}
           />
         </ReactNativeZoomableView>
       </SafeAreaView>

--- a/src/media/PDFScreen.tsx
+++ b/src/media/PDFScreen.tsx
@@ -4,6 +4,7 @@ import { StyleSheet, View } from "react-native";
 import { Colors } from "react-native-paper";
 import Pdf from "react-native-pdf";
 import { SafeAreaView } from "react-native-safe-area-context";
+import { getPath } from "../store/mediaService";
 import { MapNaviationProp } from "../types/nav/map";
 import AcknowledgementsOverlay from "./AcknowledgementsOverlay";
 
@@ -15,7 +16,7 @@ const PDFScreen: React.FC = () => {
   return (
     <View style={styles.container}>
       <SafeAreaView style={[StyleSheet.absoluteFill]}>
-        <Pdf source={{ uri: media.path }} style={styles.pdf} />
+        <Pdf source={{ uri: getPath(media) }} style={styles.pdf} />
       </SafeAreaView>
       <AcknowledgementsOverlay acknowledgements={media.acknowledgements} />
     </View>

--- a/src/store/experience/experienceEpic.ts
+++ b/src/store/experience/experienceEpic.ts
@@ -52,7 +52,7 @@ const loadFeaturedExperiencesEpic = (action$: Observable<any>) =>
           loadedFeaturedExperiences({ featuredExperiences: response })
         ),
         catchError((e) => {
-          Alert.alert("Error", JSON.stringify(e));
+          // Alert.alert("Error", JSON.stringify(e));
           return EMPTY;
         })
       )
@@ -121,7 +121,10 @@ const downloadExperienceMediaEpic = (
             media: m.reduce(
               (prev, curr) => ({
                 ...prev,
-                [curr._id]: curr,
+                [curr._id]: {
+                  ...curr,
+                  localPath: `${dirs.DocumentDir}/${curr._id}`,
+                },
               }),
               {}
             ),
@@ -176,7 +179,7 @@ const removeExperienceEpic = (
             );
           }),
           catchError((e) => {
-            Alert.alert(JSON.stringify(e));
+            // Alert.alert(JSON.stringify(e));
             return EMPTY;
           })
         );

--- a/src/store/geofence/geofenceEpic.ts
+++ b/src/store/geofence/geofenceEpic.ts
@@ -49,7 +49,7 @@ const onSetSelectedExperienceEpic = (
       from(setGeofences(experience)).pipe(
         ignoreElements(),
         catchError((e) => {
-          Alert.alert(JSON.stringify(e));
+          // Alert.alert(JSON.stringify(e));
           return EMPTY;
         })
       )

--- a/src/store/rootEpic.ts
+++ b/src/store/rootEpic.ts
@@ -24,7 +24,11 @@ export default (
     catchError((error, source) => {
       console.error("global catchError hit");
       console.error(error);
-      crashlytics().recordError(error);
+      try {
+        crashlytics().recordError(error);
+      } catch (e) {
+        console.log("Cannot parse error");
+      }
       return source;
     })
   );

--- a/src/types/common/experience.ts
+++ b/src/types/common/experience.ts
@@ -58,7 +58,7 @@ export type ExperienceRefData = {
   _id: string;
   snapshotId: string;
   name: string;
-  description: string;
+  description?: string;
   metaData: MetaData;
 };
 

--- a/src/types/nav/addExperience.ts
+++ b/src/types/nav/addExperience.ts
@@ -1,9 +1,9 @@
-import { ExperienceData, ExperienceRefData } from "../common/experience";
+import { ExperienceRefData } from "../common/experience";
 
 export type AddExperienceProp = {
   FeaturedExperienceScreen: {};
   ExperienceDetailsScreen: {
-    experience?: ExperienceRefData | ExperienceData;
+    experience?: ExperienceRefData;
     experienceId?: string;
   };
   ScanQRCodeScreen: {};

--- a/src/types/nav/experienceManagement.ts
+++ b/src/types/nav/experienceManagement.ts
@@ -1,9 +1,9 @@
-import { ExperienceData, ExperienceRefData } from "../common/experience";
+import { ExperienceRefData } from "../common/experience";
 
 export type ExperienceManagementProp = {
   ManageExperiencesScreen: {};
   ExperienceDetailsScreen: {
-    experience?: ExperienceRefData | ExperienceData;
+    experience?: ExperienceRefData;
     experienceId?: string;
   };
 };

--- a/src/ui/OfflineBanner.tsx
+++ b/src/ui/OfflineBanner.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from "react";
+import { useTranslation } from "react-i18next";
+import { Banner } from "react-native-paper";
+import useIsOnline from "../hooks/useIsOnline";
+
+type Props = {
+  title?: string;
+};
+
+const OfflineBanner: React.VFC<Props> = ({ title }) => {
+  const isOnline = useIsOnline();
+  const [hasDismissed, setHasDismissed] = useState(false);
+  const [t] = useTranslation(["glossary", "manage"]);
+  return (
+    <Banner
+      visible={isOnline !== null && !isOnline && !hasDismissed}
+      icon="cloud-off-outline"
+      actions={[
+        {
+          label: t("glossary:continue"),
+          onPress: () => setHasDismissed(true),
+        },
+      ]}
+    >
+      {title || t("manage:youAreOffline")}
+    </Banner>
+  );
+};
+
+export default OfflineBanner;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2189,6 +2189,11 @@
   resolved "https://registry.yarnpkg.com/@react-native-community/masked-view/-/masked-view-0.1.11.tgz#2f4c6e10bee0786abff4604e39a37ded6f3980ce"
   integrity sha512-rQfMIGSR/1r/SyN87+VD8xHHzDYeHaJq6elOSCAD+0iLagXkSI2pfA0LmSXP21uw5i3em7GkkRjfJ8wpqWXZNw==
 
+"@react-native-community/netinfo@^9.3.0":
+  version "9.3.0"
+  resolved "https://registry.yarnpkg.com/@react-native-community/netinfo/-/netinfo-9.3.0.tgz#9792c23341eab5c629566baee016146f4f3f6086"
+  integrity sha512-NNdMeIXXqmPCbXrWxVqRzZ1gEZ6L1ykotWnCZLVjQBUgjyGWdL5LiDM/bcIa5DLzqZY7Km08rMgB7BoHUuEmnQ==
+
 "@react-native-community/progress-bar-android@^1.0.4":
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/@react-native-community/progress-bar-android/-/progress-bar-android-1.0.4.tgz#2601353b23a7ad76a59e5b0981e0b08c39902708"


### PR DESCRIPTION
Improves the handling of experiences while the app is offline

- Fixes offline media items not showing
- Adds a banner when viewing an experience while offline, to warn if it has not been downloaded
- Uses the experience data ref on experience details screen, so we don't rely on the experience snapshot being there to render